### PR TITLE
A little more info when tests fail

### DIFF
--- a/pytests/__init__.py
+++ b/pytests/__init__.py
@@ -58,5 +58,10 @@ class Reasoner(unittest.TestCase):
             base_url=BASE_URL)
         headers = {'Content-Type': 'application/json',
                    'Authorization': 'Bearer {token}'.format(token=TOKEN)}
-        self.response = requests.post(
-            url, headers=headers, data=json.dumps(self.body)).json()
+        response = requests.post(
+            url, headers=headers, data=json.dumps(self.body))
+        try:
+            self.response = response.json()
+        except:
+            print(response.text)
+            raise


### PR DESCRIPTION
info like this

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-------------------- >> begin captured stdout << ---------------------
Failed to validate against schema. reason:
Property failure
|
`- parents failed
   |
   `- Property failure




```