### PR TITLE
More tests of WFF PTC when other entitlements or ACC

### DIFF
--- a/pytests/test_wff_parental_tax_credit.py
+++ b/pytests/test_wff_parental_tax_credit.py
@@ -34,6 +34,11 @@ class TestWFF_ParentalTaxCredit(TestKey):
         "applicant": {
             "isPrincipalCarerForProportion": 34,
             "receivesIncomeTestedBenefit": False
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 
@@ -41,11 +46,45 @@ class TestWFF_ParentalTaxCredit(TestKey):
         self.assertTrue(self.is_permitted)
 
 
+class TestWFF_ParentalTaxCreditNullThreshold(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 34,
+            "receivesIncomeTestedBenefit": False
+        }
+    }
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
+class TestWFF_ParentalTaxCreditNotThreshold(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 34,
+            "receivesIncomeTestedBenefit": False
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": False
+            }
+        }
+    }
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
 class TestWFF_ParentalLessChildcare(TestKey):
     body = {
         "applicant": {
             "isPrincipalCarerForProportion": 4,
             "receivesIncomeTestedBenefit": False
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 
@@ -58,6 +97,11 @@ class TestWFF_ParentalTaxCreditOnMTBenefit(TestKey):
         "applicant": {
             "isPrincipalCarerForProportion": 100,
             "receivesIncomeTestedBenefit": True
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 
@@ -71,6 +115,11 @@ class TestWFF_ParentalTaxCreditForbiddenOnAcc(TestKey):
             "isPrincipalCarerForProportion": 34,
             "receivesIncomeTestedBenefit": False,
             "isOnACCCompensation": True
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 
@@ -95,6 +144,11 @@ class TestWFF_ParentalTaxCreditForbiddenOrphans(TestKey):
         },
         "parents": {
             "areDeceasedMissingOrIncapable": True
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 
@@ -114,6 +168,11 @@ class TestWFF_ParentalTaxCreditForbiddenStudents(TestKey):
             "normallyLivesInNZ": True,
             "Age": 25,
             "isStudyingFullTime": True,
+        },
+        "threshold": {
+            "income": {
+                "workingForFamiliesParentalTaxCredit": True
+            }
         }
     }
 

--- a/pytests/test_wff_parental_tax_credit.py
+++ b/pytests/test_wff_parental_tax_credit.py
@@ -177,6 +177,6 @@ class TestWFF_ParentalTaxCreditForbiddenStudents(TestKey):
     }
 
     def test_reasoning(self):
-        # Orphans benefit is permitted, so WFF PTC is not
+        # Student allowance is permitted, so WFF PTC is not
         self.assertTrue(self.isPermitted('isStudentAllowance'))
         self.assertTrue(self.is_forbidden)

--- a/pytests/test_wff_parental_tax_credit.py
+++ b/pytests/test_wff_parental_tax_credit.py
@@ -22,6 +22,13 @@ Applicant is NOT eligible if they:
 """
 
 
+class TestWFF_ParentalTaxCreditDefault(TestKey):
+    body = {}
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
 class TestWFF_ParentalTaxCredit(TestKey):
     body = {
         "applicant": {
@@ -32,3 +39,85 @@ class TestWFF_ParentalTaxCredit(TestKey):
 
     def test_reasoning(self):
         self.assertTrue(self.is_permitted)
+
+
+class TestWFF_ParentalLessChildcare(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 4,
+            "receivesIncomeTestedBenefit": False
+        }
+    }
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
+class TestWFF_ParentalTaxCreditOnMTBenefit(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 100,
+            "receivesIncomeTestedBenefit": True
+        }
+    }
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
+class TestWFF_ParentalTaxCreditForbiddenOnAcc(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 34,
+            "receivesIncomeTestedBenefit": False,
+            "isOnACCCompensation": True
+        }
+    }
+
+    def test_reasoning(self):
+        self.assertTrue(self.is_forbidden)
+
+
+class TestWFF_ParentalTaxCreditForbiddenOrphans(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 34,
+            "receivesIncomeTestedBenefit": False,
+            # add the orphans bene requirements
+            "Age": 87,
+            "isNZResident": True,
+            "isParent": False,
+            "isPrincipalCarerForOneYearFromApplicationDate": True,
+            "normallyLivesInNZ": True
+        },
+        "child": {
+            "isDependent": True
+        },
+        "parents": {
+            "areDeceasedMissingOrIncapable": True
+        }
+    }
+
+    def test_reasoning(self):
+        # Orphans benefit is permitted, so WFF PTC is not
+        self.assertTrue(self.isPermitted('isOrphansBenefit'))
+        self.assertTrue(self.is_forbidden)
+
+
+class TestWFF_ParentalTaxCreditForbiddenStudents(TestKey):
+    body = {
+        "applicant": {
+            "isPrincipalCarerForProportion": 34,
+            "receivesIncomeTestedBenefit": False,
+            # add the student allowance requirements
+            "isNZResident": True,
+            "normallyLivesInNZ": True,
+            "Age": 25,
+            "isStudyingFullTime": True,
+        }
+    }
+
+    def test_reasoning(self):
+        # Orphans benefit is permitted, so WFF PTC is not
+        self.assertTrue(self.isPermitted('isStudentAllowance'))
+        self.assertTrue(self.is_forbidden)


### PR DESCRIPTION
Tests of more scenarios

Forbidden when: 
* less than 33% of care
* on means tested benefit
* eligible for Student allowance, orphans or unsupported child
* on ACC

Permitted when:
* null values for ACC

